### PR TITLE
Correção de dado da coluna 1001

### DIFF
--- a/capitulo4/buscas.csv
+++ b/capitulo4/buscas.csv
@@ -998,4 +998,4 @@ home,busca,logado,comprou
 0,ruby,0,sim
 0,java,1,sim
 1,algoritmos,0,sim
-0,ruby,1,0
+0,ruby,1,nao


### PR DESCRIPTION
Quando utilizei o _Counter_ na coluna *comprou* foi retornado uma item do dictiory com valor '0'. O que não deveria para o exercícios do capítulo 4. Abraços!